### PR TITLE
Enable code coverage reporting

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,3 +3,5 @@ require 'puppetlabs_spec_helper/module_spec_helper'
 RSpec.configure do |c|
   c.hiera_config = File.expand_path(File.join(__FILE__, '../fixtures/hiera.yaml'))
 end
+
+at_exit { RSpec::Puppet::Coverage.report! }


### PR DESCRIPTION
Turn on the code coverage reporting so it's obvious what still needs
test work.

Signed-off-by: Andrew Grimberg agrimberg@linuxfoundation.org
